### PR TITLE
Support windows-style new line characters

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -58,7 +58,7 @@ export default function (options = {}) {
 		generateBundle(options, bundle) {
 			var code = cached.fragments.join('')
 			for (var name in bundle) {
-				bundle[name].code += "\n" + (styleInject.toString()) + ";\nstyleInject(\"" + buildID + "\", \"" + (code.replace(/\n/g, '').replace(/"/g, '\\"')) + "\");";
+				bundle[name].code += "\n" + (styleInject.toString()) + ";\nstyleInject(\"" + buildID + "\", \"" + (code.replace(/\r?\n/g, '').replace(/"/g, '\\"')) + "\");";
 			}
 		}
 	}


### PR DESCRIPTION
When code checkout to windows - git replaces \n by \r\n - css plugin seems to not expect such an option and produces unexpected newlines in output.